### PR TITLE
remove -Wcheck flag which isn't recognized by oneapi/icx

### DIFF
--- a/config/intel-warnings/general
+++ b/config/intel-warnings/general
@@ -1,2 +1,1 @@
 -Wall
--Wcheck


### PR DESCRIPTION
configuring with the oneapi C compiler (icx) will fail if the -Wcheck flag is present. This PR does not address the intent of the original check in the configure process. Removing the flag was observed to allow the install to complete and pass tests on a linux-opensuse_leap15-zen2 platform. 

Adresses https://github.com/HDFGroup/hdf5/issues/750